### PR TITLE
Handle empty parameter conversion

### DIFF
--- a/e2e/specs/parameters.spec
+++ b/e2e/specs/parameters.spec
@@ -1,0 +1,5 @@
+# Paramters
+
+## Check parameter conversion
+
+* Trimmed " " is the same as ""

--- a/e2e/tests/parameter.ts
+++ b/e2e/tests/parameter.ts
@@ -1,0 +1,9 @@
+import * as assert from "node:assert";
+import { Step } from "gauge-ts";
+
+export default class Parameter {
+  @Step("Trimmed <original> is the same as <expected>")
+  public async checkTrimmeWord(original: string, expected: string) {
+    assert.strictEqual(original.trim(), expected);
+  }
+}

--- a/gauge-ts/src/processors/params/PrimitiveParser.ts
+++ b/gauge-ts/src/processors/params/PrimitiveParser.ts
@@ -27,6 +27,7 @@ export class PrimitiveParser implements ParameterParser {
   }
 
   private convertToNumber(value: string): number | undefined {
+    if (value.trim() === "") return undefined;
     const num = Number(value);
     return Number.isNaN(num) ? undefined : num;
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,8 +22,8 @@
         "typescript": "^5.4.5"
       },
       "devDependencies": {
-        "@getgauge/cli": "*",
-        "@types/node": "*",
+        "@getgauge/cli": "latest",
+        "@types/node": "latest",
         "taiko": "^1.4.0",
         "tsconfig-paths": "^4.2.0"
       }


### PR DESCRIPTION
Noticed an issue with parameter conversion while running the test case in Taiko

https://github.com/getgauge/taiko/blob/b4b6fbccf34c0faed59c38664faf48ade0e292e0/test/functional-tests/specs/pageActions.spec#L92

Empty text get's converted to number.

For example in the original logic

```
Number("  ") === 0
```

This causes the wrong type to be passed. 